### PR TITLE
Implemented get_check_constraints method

### DIFF
--- a/sqla_vertica_python/vertica_python.py
+++ b/sqla_vertica_python/vertica_python.py
@@ -220,6 +220,34 @@ class VerticaDialect(PGDialect):
 
         return result
 
+    @reflection.cache
+    def get_check_constraints(
+            self, connection, table_name, schema=None, **kw):
+
+        _schema_clause = ""
+        if schema is not None:
+            _schema_clause = " table_schema ='"+ schema +"' AND "
+
+        query = (
+            " SELECT                                      \n"
+            "    cons.constraint_name as name,            \n"
+            "    cons.predicate as src                    \n"
+            "  FROM                                       \n"
+            "    v_catalog.table_constraints cons         \n"
+            " WHERE                                       \n"
+            "   cons.table_name = '"+table_name+"' AND    \n"
+            "   "+_schema_clause+"                        \n"
+            "   cons.constraint_type = 'c'                "
+        )
+
+        c = connection.execute(query)
+
+        return [
+            {'name': name,
+             'sqltext': src[1:-1]}
+            for name, src in c.fetchall()
+            ]
+
     # constraints are enforced on selects, but returning nothing for these
     # methods allows table introspection to work
 

--- a/sqla_vertica_python/vertica_python.py
+++ b/sqla_vertica_python/vertica_python.py
@@ -226,7 +226,7 @@ class VerticaDialect(PGDialect):
 
         _schema_clause = ""
         if schema is not None:
-            _schema_clause = " table_schema ='"+ schema +"' AND "
+            _schema_clause = " AND i.table_schema ='"+ schema +"' "
 
         query = (
             " SELECT                                      \n"
@@ -235,9 +235,12 @@ class VerticaDialect(PGDialect):
             "  FROM                                       \n"
             "    v_catalog.table_constraints cons         \n"
             " WHERE                                       \n"
-            "   cons.table_name = '"+table_name+"' AND    \n"
-            "   "+_schema_clause+"                        \n"
-            "   cons.constraint_type = 'c'                "
+            "   cons.table_id =                           \n"
+            "        (select i.table_id from              \n"
+            "           v_catalog.tables i                \n"
+            "         where i.table_name='"+table_name+"'   \n"
+            "         "+_schema_clause+ " )               \n"
+            "   AND cons.constraint_type = 'c'              "
         )
 
         c = connection.execute(query)


### PR DESCRIPTION
When using this connector to plug in a Vertica database into [Superset](https://github.comapache/incubator-superset), I had an error (attached to the end) while trying to import a table.

```
(...)
Schema "pg_catalog" does not exist
(...)
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/dialects/postgresql/base.py", line 2881, in get_check_constraints
    info_cache=kw.get('info_cache'))
(...)
```

So the stack needed at some point to run this get_checks_constraint method.

Then I've got the code for the PGSQL connector and adapted the table names to match Vertica tables.

**Full error**

```
2017-08-11 16:29:34,146:ERROR:root:(vertica_python.errors.MissingSchema) Severity: ERROR, Message: Schema "pg_catalog" does not exist, Sqlstate: 3F000, Routine: RangeVarGetObjid, File: /scratch_a/release/svrtar11561/vbuild/vertica/Catalog/Namespace.cpp, Line: 288, SQL: u"             SELECT c.oid             FROM pg_catalog.pg_class c             LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace             WHERE (n.nspname = 'dw')             AND c.relname = 'fact_market' AND c.relkind in ('r', 'v', 'm', 'f')         " [SQL: "\n            SELECT c.oid\n            FROM pg_catalog.pg_class c\n            LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace\n            WHERE (n.nspname = :schema)\n            AND c.relname = :table_name AND c.relkind in ('r', 'v', 'm', 'f')\n        "] [parameters: {'table_name': u'fact_market', 'schema': 'dw'}]
Traceback (most recent call last):
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/superset/connectors/sqla/views.py", line 239, in pre_add
    table.get_sqla_table_object()
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/superset/connectors/sqla/models.py", line 574, in get_sqla_table_object
    return self.database.get_table(self.table_name, schema=self.schema)
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/superset/models/core.py", line 685, in get_table
    autoload_with=self.get_sqla_engine())
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/sql/schema.py", line 439, in __new__
    metadata._remove_table(name, schema)
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/util/langhelpers.py", line 66, in __exit__
    compat.reraise(exc_type, exc_value, exc_tb)
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/sql/schema.py", line 434, in __new__
    table._init(name, metadata, *args, **kw)
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/sql/schema.py", line 514, in _init
    include_columns, _extend_on=_extend_on)
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/sql/schema.py", line 527, in _autoload
    _extend_on=_extend_on
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 2045, in run_callable
    return conn.run_callable(callable_, *args, **kwargs)
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1534, in run_callable
    return callable_(self, *args, **kwargs)
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/engine/default.py", line 372, in reflecttable
    table, include_columns, exclude_columns, **opts)
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/engine/reflection.py", line 625, in reflecttable
    include_columns, exclude_columns, reflection_options)
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/engine/reflection.py", line 836, in _reflect_check_constraints
    constraints = self.get_check_constraints(table_name, schema)
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/engine/reflection.py", line 533, in get_check_constraints
    self.bind, table_name, schema, info_cache=self.info_cache, **kw)
  File "<string>", line 2, in get_check_constraints
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/engine/reflection.py", line 54, in cache
    ret = fn(self, con, *args, **kw)
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/dialects/postgresql/base.py", line 2881, in get_check_constraints
    info_cache=kw.get('info_cache'))
  File "<string>", line 2, in get_table_oid
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/engine/reflection.py", line 54, in cache
    ret = fn(self, con, *args, **kw)
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/dialects/postgresql/base.py", line 2320, in get_table_oid
    c = connection.execute(s, table_name=table_name, schema=schema)
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 945, in execute
    return meth(self, multiparams, params)
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/sql/elements.py", line 263, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1053, in _execute_clauseelement
    compiled_sql, distilled_params
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1189, in _execute_context
    context)
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1402, in _handle_dbapi_exception
    exc_info
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/util/compat.py", line 203, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb, cause=cause)
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1182, in _execute_context
    context)
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/sqlalchemy/engine/default.py", line 470, in do_execute
    cursor.execute(statement, parameters)
  File "/home/ubuntu/cassius-superset/local/lib/python2.7/site-packages/vertica_python/vertica/cursor.py", line 116, in execute
    raise errors.QueryError.from_error_response(self._message, operation)
ProgrammingError: (vertica_python.errors.MissingSchema) Severity: ERROR, Message: Schema "pg_catalog" does not exist, Sqlstate: 3F000, Routine: RangeVarGetObjid, File: /scratch_a/release/svrtar11561/vbuild/vertica/Catalog/Namespace.cpp, Line: 288, SQL: u"             SELECT c.oid             FROM pg_catalog.pg_class c             LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace             WHERE (n.nspname = 'dw')             AND c.relname = 'fact_market' AND c.relkind in ('r', 'v', 'm', 'f')         " [SQL: "\n            SELECT c.oid\n            FROM pg_catalog.pg_class c\n            LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace\n            WHERE (n.nspname = :schema)\n            AND c.relname = :table_name AND c.relkind in ('r', 'v', 'm', 'f')\n        "] [parameters: {'table_name': u'fact_market', 'schema': 'dw'}]
```