### PR TITLE
Bugfix: timestamptz is accepted as an abbreviation for timestamp with…

### DIFF
--- a/sqla_vertica_python/vertica_python.py
+++ b/sqla_vertica_python/vertica_python.py
@@ -29,6 +29,7 @@ class VerticaDialect(PGDialect):
         'TIME': sqltypes.TIME,
         'TIME': sqltypes.TIME(timezone=True),
         'TIMESTAMP': sqltypes.TIMESTAMP,
+        'TIMESTAMPTZ': sqltypes.TIMESTAMP(timezone=True),
         'TIMESTAMP WITH TIMEZONE': sqltypes.TIMESTAMP(timezone=True),
 
         # Not supported yet


### PR DESCRIPTION
… time zone but not supported

https://my.vertica.com/docs/8.1.x/HTML/index.htm#Authoring/SQLReferenceManual/DataTypes/Date-Time/TIMESTAMP.htm%3FTocPath%3DSQL%2520Reference%2520Manual%7CSQL%2520Data%2520Types%7CDate%252FTime%2520Data%2520Types%7C_____7