### PR TITLE
Fix to support compatability with SQLAlchemy>=1.2.0

### DIFF
--- a/sqla_vertica_python/vertica_python.py
+++ b/sqla_vertica_python/vertica_python.py
@@ -136,6 +136,11 @@ class VerticaDialect(PGDialect):
 
 
     @reflection.cache
+    def get_table_comment(self, connection, table_name, schema=None, **kw):
+        raise NotImplementedError
+
+
+    @reflection.cache
     def get_table_names(self, connection, schema=None, **kw):
         s = ["SELECT table_name FROM v_catalog.tables"]
         if schema is not None:

--- a/sqla_vertica_python/vertica_python.py
+++ b/sqla_vertica_python/vertica_python.py
@@ -137,7 +137,15 @@ class VerticaDialect(PGDialect):
 
     @reflection.cache
     def get_table_comment(self, connection, table_name, schema=None, **kw):
-        raise NotImplementedError
+        schema_conditional = (
+            "" if schema is None else "AND object_schema = '{schema}'".format(schema=schema))
+        query = """
+        SELECT comment FROM v_catalog.comments WHERE object_type = 'TABLE'
+        AND object_name = '{table_name}'
+        {schema_conditional}
+        """.format(table_name=table_name, schema_conditional=schema_conditional)
+        rs = connection.execute(query)
+        return {"text": rs.scalar()}
 
 
     @reflection.cache


### PR DESCRIPTION
This fulfills the interface described [here](http://docs.sqlalchemy.org/en/latest/core/reflection.html#sqlalchemy.engine.reflection.Inspector.get_table_comment) for versions of SQLAlchemy >= 1.2.0.

@lemeryfertitta 