### PR TITLE
FIX: support native decimal conversions

### DIFF
--- a/sqla_vertica_python/vertica_python.py
+++ b/sqla_vertica_python/vertica_python.py
@@ -11,6 +11,8 @@ class VerticaDialect(PGDialect):
     name = 'vertica'
 
     driver = 'vertica_python'
+    
+    supports_native_decimal = True
 
     ischema_names = {
         'BINARY': sqltypes.BLOB,


### PR DESCRIPTION
Vertica supports Decimal/Numeric, and SQLAlchemy converting to float causes big issues when using high-precision (>16) Numeric types.