### PR TITLE
FIX: support_unicode_statements for VerticaDialect

### DIFF
--- a/sqla_vertica_python/vertica_python.py
+++ b/sqla_vertica_python/vertica_python.py
@@ -9,8 +9,10 @@ class VerticaDialect(PGDialect):
     """ Vertica Dialect using a vertica-python connection and PGDialect """
 
     name = 'vertica'
-
     driver = 'vertica_python'
+    
+    supports_unicode_statements = True
+    supports_unicode_binds = True
 
     ischema_names = {
         'BINARY': sqltypes.BLOB,


### PR DESCRIPTION
SQLAlchemy will convert unicode to str (py3 bytes) in PY2 unless the Dialect specifies these supports_unicode_* flags. This can lead to weird errors because vertica_python actually converts strings back to unicode (py3 str) in its cursor: https://github.com/uber/vertica-python/blame/master/vertica_python/vertica/cursor.py#L355-L394

(creating this separately from the supports_native_decimal change so we can discuss them separately, they seem like different issues)