### PR TITLE
Override PGDialect initialize

### DIFF
--- a/sqla_vertica_python/vertica_python.py
+++ b/sqla_vertica_python/vertica_python.py
@@ -60,6 +60,10 @@ class VerticaDialect(PGDialect):
         'MONEY': sqltypes.NUMERIC,
     }
 
+    # skip all the version-specific stuff in PGDialect's initialize method (Vertica versions don't match feature-wise)
+    def initialize(self, connection):
+        super(PGDialect, self).initialize(connection)
+        self.implicit_returning = False
 
     @classmethod
     def dbapi(cls):


### PR DESCRIPTION
PGDialect initialize sets a number of flags based on Postgres server version, but the Vertica server version doesn't match functionality.  Notably, a lot changed in PG 8.x, and now that Vertica is in the 9.x release, some of these version checks are triggering and impacting functionality of this dialect.

This pull request overrides the PGDialect version-specific initialize implementation and set flags compatible with Vertica.

(Disclaimer: I am a Micro Focus - Vertica employee)