### PR TITLE
Add IDENTITY support when creating DDL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,7 @@ setup(
     vertica.vertica_python = sqla_vertica_python.vertica_python:VerticaDialect
     """,
     install_requires=[
-        'vertica_python',
-        'psycopg2'
+        'vertica_python'
     ],
 )
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = '0.4.1'
+version = '0.4.2'
 setup(
     name='sqlalchemy-vertica-python',
     version=version,

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
     vertica.vertica_python = sqla_vertica_python.vertica_python:VerticaDialect
     """,
     install_requires=[
-        'vertica_python'
+        'vertica_python',
+        'psycopg2'
     ],
 )
 

--- a/sqla_vertica_python/vertica_python.py
+++ b/sqla_vertica_python/vertica_python.py
@@ -3,6 +3,17 @@ from sqlalchemy import types as sqltypes
 from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.dialects.postgresql import INTERVAL
 from sqlalchemy.engine import reflection
+from sqlalchemy.schema import CreateColumn
+from sqlalchemy.ext.compiler import compiles
+
+
+# From Postgresql 10 IDENTITY columns section in sqlalchemy/dialects/postgresql/base.py
+@compiles(CreateColumn, 'vertica')
+def use_identity(element, compiler, **kw):
+    text = compiler.visit_create_column(element, **kw)
+    text = text.replace("SERIAL", "IDENTITY(1,1)")
+    return text
+
 
 class VerticaDialect(PGDialect):
     """ Vertica Dialect using a vertica-python connection and PGDialect """


### PR DESCRIPTION
The following patch will replace occurrences of SERIAL with IDENTITY as described in the postgresql base.py dialect.