### PR TITLE
Allows UPDATE statement to work and installs optional vertica python dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,3 +22,17 @@ From git: ::
      git clone https://github.com/LocusEnergy/vertica-sqlalchemy 
      cd vertica-sqlalchemy
      python setup.py install
+     
+
+Usage
+------------
+
+**ID/Primary Key Declaration**
+
+Do not use this. The INSERT will fail as it will try to insert the ID
+
+    id = Column(Integer, primary_key=True)
+
+Do the following instead
+
+    id = Column(Integer, Sequence('user_id_seq'), primary_key=True)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     vertica.vertica_python = sqla_vertica_python.vertica_python:VerticaDialect
     """,
     install_requires=[
-        'vertica_python'
+        'vertica_python[namedparams]'
     ],
 )
 

--- a/sqla_vertica_python/vertica_python.py
+++ b/sqla_vertica_python/vertica_python.py
@@ -21,6 +21,9 @@ class VerticaDialect(PGDialect):
     name = 'vertica'
     driver = 'vertica_python'
     
+    # UPDATE functionality works with the following option set to False
+    supports_sane_rowcount = False
+    
     supports_unicode_statements = True
     supports_unicode_binds = True
     supports_native_decimal = True


### PR DESCRIPTION
SQLAlchemy uses named parameters and the setup.py does not install the optional dependencies (psycopg2). This fix will install psycopg2 dependencies. See https://github.com/vertica/vertica-python/pull/247

Adding supports_sane_rowcount = False seems to fix the UPDATE rowcount issue for me

Updated the README file to help with id usage
