### PR TITLE
Add PK Support and limit Unique Constraint

### DIFF
--- a/sqla_vertica_python/vertica_python.py
+++ b/sqla_vertica_python/vertica_python.py
@@ -363,12 +363,11 @@ class VerticaDialect(PGDialect):
     @reflection.cache
     def get_pk_constraint(self, connection, table_name, schema=None, **kw):
         query = "SELECT constraint_id, constraint_name, column_name FROM v_catalog.constraint_columns \n\
-                  WHERE table_name = '" + table_name + "'"
+                 WHERE constraint_type = 'p' AND table_name = '" + table_name + "'"
+
         if schema is not None: 
             query += " AND table_schema = '" + schema + "' \n"
-        query += "AND constraint_type = 'p'"
 
-        rs = connection.execute(query)
         cols = set()
         name = set()
         for row in connection.execute(query):


### PR DESCRIPTION
The following changes allows sqlacodegen to return the class instead of the Table for code generation by returning the columns with a PK and narrowing the constraints for unique as seen in the diff files.

Originally class defined in the model:

Defined in SQLAlchemy as

```
class Person(SAFRSBase, db.Model):
    '''
        description: People description
    '''
    __tablename__ = 'People'
    id = db.Column(db.String, primary_key=True)
    name = db.Column(db.String, default = '')
    email = db.Column(db.String, default = '')
    comment = db.Column(db.Text, default = '')

```

With current code, sqlacodegen returns:

```
# coding: utf-8
from sqlalchemy import Column, MetaData, String, Table, text

metadata = MetaData()


t_People = Table(
    'People', metadata,
    Column('id', String(80), nullable=False, server_default=text("")),
    Column('email', String(80), server_default=text("")),
    Column('comment', String(1048576), server_default=text("")),
    Column('name', String(80), server_default=text("")),
    UniqueConstraint(),
    UniqueConstraint(),
    schema='inv'
)
```

With proposed patch, the code returns:

```
# coding: utf-8
from sqlalchemy import Column, String, text
from sqlalchemy.ext.declarative import declarative_base

Base = declarative_base()
metadata = Base.metadata


class Person(Base):
    __tablename__ = 'People'
    __table_args__ = {'schema': 'inv'}

    id = Column(String(80), primary_key=True, server_default=text(""))
    email = Column(String(80), server_default=text(""))
    comment = Column(String(1048576), server_default=text(""))
    name = Column(String(80), server_default=text(""))

```

Thanks for your consideration