### PR TITLE
Provide columns from get_columns() in same order as defined in table

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = '0.4.4'
+version = '0.4.5'
 setup(
     name='sqlalchemy-vertica-python',
     version=version,
@@ -22,4 +22,3 @@ setup(
         'vertica_python[namedparams]'
     ],
 )
-


### PR DESCRIPTION
Hi!

I hit this issue while exporting a `CREATE TABLE` statement using SqlAlchemy's [CreateTable](https://docs.sqlalchemy.org/en/13/core/ddl.html#sqlalchemy.schema.CreateTable) class to create a landing space for table whose data I was moving from database to database.  CreateTable uses the `get_columns()` method in the dialect class.  

Because the columns weren't returned in the same order as they're defined in the table, the generated `CREATE TABLE` statement didn't generate a compatible table.

This updates the `get_columns()` method to use Vertica's `ordinal_position` column to output in the same order.

(sorry about the unrelated whitespace cleanups; my editor has strong opinions, it appears)