### PR TITLE
Fix upstream issue #36

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     vertica.vertica_python = sqla_vertica_python.vertica_python:VerticaDialect
     """,
     install_requires=[
-        'vertica_python[namedparams]'
+        'vertica_python'
     ],
 )
 


### PR DESCRIPTION
Fix upstream issue #36 by removing [namedparams] since vertica-python no longer includes this.  [namedparams] was removed when the psycopg2 dependency was removed.